### PR TITLE
feat: Updates for new SavantOS 11.0.5+ to rubi.sh while maintaining b…

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ bash <(curl -Ls "https://github.com/benumc/rubi/raw/main/rubi.sh")
 Uninstall by connecting the same way and running:
 sclibridge removetrigger rubi && sclibridge removetrigger rbwd && sleep 5 && pkill -f rubi
 
+## Profile Types
+
+### Rubi Profiles
 rubi based profiles should use the following control interfaces:
   <control_interfaces preferred="ip">
     <ip port="25809" response_time_length_ms="1000" protocol="tcp">
@@ -17,7 +20,24 @@ rubi based profiles should use the following control interfaces:
       <receive_end_condition test_condition="data" type="hex">0A</receive_end_condition>
     </ip>
   </control_interfaces>
-  
+
+### Script Bridge Profile
+The `benumc_script-bridge-rubi.xml` profile provides a drop-in replacement for existing script-bridge functionality to work with rubi co-processor. This allows existing script-based profiles to work with rubi without modification.
+
+**Recent Enhancements:**
+- **Cross-platform support**: Automatically detects correct Savant installation paths on both macOS and Linux
+- **Robust port management**: Intelligent conflict resolution for port 25768 using multiple detection methods (lsof, netstat, process name matching)
+- **Enhanced error handling**: Better logging and graceful failure recovery
+- **Process cleanup**: Automatic cleanup of orphaned script bridge processes on startup
+- **Standalone script**: Available as both embedded XML and standalone `script_bridge.rb` for development/debugging
+
+**Usage:**
+- Set Address on wire to 127.0.0.1
+- Uses port 25768 for script bridge communication
+- Automatically handles path detection and process management
+- Compatible with existing script-based profiles
+
+## Development
 
 All commands should be formatted as ruby instructions.
 Any multi-line instrunction including large code blocks should be wrapped in standard <![CDATA[ ]]> tags.
@@ -29,5 +49,14 @@ Commands can be sent to rubi for example: print(RUBY_VERSION)\h0A which will pri
 Blocking commands should be avoided until debugging is complete. It is probably better to fire a "myThread = Thread.new{some_code}" that can be killed "Thread.kill(my_thread)" if needed than to block the main thread as instructions will no longer be executed until the blocking code returns.
 
 Don't use global variables $my_var use instance variables @my_var if you need to share values through your code.
+
+## Files
+
+- `script_bridge.rb` - Standalone version of the script bridge server (extracted from XML for easier development)
+- `benumc_script-bridge-rubi.xml` - Complete profile with embedded script bridge functionality
+- `rubi.sh` - Installation script
+- Other XML profiles demonstrate various rubi implementations
+
+## Support
 
 I may not always reply right away, but please feel free to contact me on the Savant Programmers Slack chat if you have questions or issues.

--- a/benumc_script-bridge-rubi.xml
+++ b/benumc_script-bridge-rubi.xml
@@ -5,7 +5,7 @@
   rpm_xml_version="2.12">
 
   <notes>
-    Drop in replacement for existing srcipt-bridge to work with rubi co-processor.
+    Drop in replacement for existing script-bridge to work with rubi co-processor.
 
     New profiles should be built to work directly with rubi but this profile can work as an in-between until they are complete
 
@@ -46,20 +46,25 @@
 require 'socket'
 include Socket::Constants
 
-# Detect profile folder path based on platform and available paths
-if RUBY_PLATFORM.include? 'linux'
-  @profile_folder = '/home/RPM/GNUstep/Library/ApplicationSupport/RacePointMedia/userConfig.rpmConfig/componentProfiles/'
-else
-  # macOS path detection
-  if Dir.exist?('/Users/Shared/Savant/Library/Application Support/RacePointMedia/userConfig.rpmConfig/componentProfiles')
-    @profile_folder = '/Users/Shared/Savant/Library/Application Support/RacePointMedia/userConfig.rpmConfig/componentProfiles/'
-  elsif Dir.exist?('/Users/RPM/Library/Application Support/RacePointMedia/userConfig.rpmConfig')
-    @profile_folder = '/Users/RPM/Library/Application Support/RacePointMedia/userConfig.rpmConfig/componentProfiles/'
+# Method to detect and set profile folder path based on platform
+def detect_profile_folder
+  if RUBY_PLATFORM.include? 'linux'
+    @profile_folder = '/home/RPM/GNUstep/Library/ApplicationSupport/RacePointMedia/userConfig.rpmConfig/componentProfiles/'
   else
-    puts "Savant Path Not Found"
-    exit 1
+    # macOS path detection
+    if Dir.exist?('/Users/Shared/Savant/Library/Application Support/RacePointMedia/userConfig.rpmConfig/componentProfiles')
+      @profile_folder = '/Users/Shared/Savant/Library/Application Support/RacePointMedia/userConfig.rpmConfig/componentProfiles/'
+    elsif Dir.exist?('/Users/RPM/Library/Application Support/RacePointMedia/userConfig.rpmConfig')
+      @profile_folder = '/Users/RPM/Library/Application Support/RacePointMedia/userConfig.rpmConfig/componentProfiles/'
+    else
+      puts "Savant Path Not Found"
+      exit 1
+    end
   end
 end
+
+# Detect profile folder path based on platform and available paths
+detect_profile_folder
 
 # Kill any existing rubi_script_bridge processes
 puts "Cleaning up existing processes..."
@@ -69,56 +74,61 @@ sleep 2  # Give processes time to die
 
 Process.setproctitle('rubi_script_bridge')
 
-# Try to bind to the port with error handling
-begin
-  @profile_connection_server = TCPServer.new('127.0.0.1',25768) #only accept local connections for security reasons.
-rescue Errno::EADDRINUSE
-  puts "Port 25768 already in use. Attempting to kill processes using the port..."
-  
-  # Try multiple methods to find and kill processes using the port
-  killed = false
-  
-  # Method 1: Try lsof if available
-  if system("which lsof > /dev/null 2>&1")
-    pids = `lsof -ti:25768 2>/dev/null`.strip
-    if !pids.empty?
-      puts "Found PIDs using lsof: #{pids}"
-      `echo "#{pids}" | xargs kill -9 2>/dev/null`
-      killed = true
-    end
-  end
-  
-  # Method 2: Try netstat on macOS
-  if !killed
-    netstat_output = `netstat -an 2>/dev/null | grep ':25768 '`.strip
-    if !netstat_output.empty?
-      puts "Found processes using netstat, attempting broader cleanup..."
-      # Kill all ruby processes that might be using the port
-      `pkill -f "ruby.*25768" 2>/dev/null`
-      `pkill -f "rubi.*script.*bridge" 2>/dev/null`
-      killed = true
-    end
-  end
-  
-  # Method 3: Kill all processes with "script_bridge" or similar names
-  if !killed
-    puts "Using process name cleanup..."
-    `pkill -f "script.*bridge" 2>/dev/null`
-    `pkill -f "rubi.*script" 2>/dev/null`
-    killed = true
-  end
-  
-  sleep 3  # Give more time for cleanup
-  
+# Method to handle port binding with cleanup and retry logic
+def bind_to_port_with_cleanup
   begin
-    @profile_connection_server = TCPServer.new('127.0.0.1',25768)
-    puts "Successfully bound to port 25768 after cleanup"
+    @profile_connection_server = TCPServer.new('127.0.0.1',25768) #only accept local connections for security reasons.
   rescue Errno::EADDRINUSE
-    puts "Unable to bind to port 25768 even after cleanup. You may need to manually kill processes."
-    puts "Try running: sudo pkill -f ruby"
-    exit 1
+    puts "Port 25768 already in use. Attempting to kill processes using the port..."
+    
+    # Try multiple methods to find and kill processes using the port
+    killed = false
+    
+    # Method 1: Try lsof if available
+    if system("which lsof > /dev/null 2>&1")
+      pids = `lsof -ti:25768 2>/dev/null`.strip
+      if !pids.empty?
+        puts "Found PIDs using lsof: #{pids}"
+        `echo "#{pids}" | xargs kill -9 2>/dev/null`
+        killed = true
+      end
+    end
+    
+    # Method 2: Try netstat on macOS
+    if !killed
+      netstat_output = `netstat -an 2>/dev/null | grep ':25768 '`.strip
+      if !netstat_output.empty?
+        puts "Found processes using netstat, attempting broader cleanup..."
+        # Kill all ruby processes that might be using the port
+        `pkill -f "ruby.*25768" 2>/dev/null`
+        `pkill -f "rubi.*script.*bridge" 2>/dev/null`
+        killed = true
+      end
+    end
+    
+    # Method 3: Kill all processes with "script_bridge" or similar names
+    if !killed
+      puts "Using process name cleanup..."
+      `pkill -f "script.*bridge" 2>/dev/null`
+      `pkill -f "rubi.*script" 2>/dev/null`
+      killed = true
+    end
+    
+    sleep 3  # Give more time for cleanup
+    
+    begin
+      @profile_connection_server = TCPServer.new('127.0.0.1',25768)
+      puts "Successfully bound to port 25768 after cleanup"
+    rescue Errno::EADDRINUSE
+      puts "Unable to bind to port 25768 even after cleanup. You may need to manually kill processes."
+      puts "Try running: sudo pkill -f ruby"
+      exit 1
+    end
   end
 end
+
+# Try to bind to the port with error handling
+bind_to_port_with_cleanup
 
 @request_pattern = /cmd:run_script&prg:(?<prg>\w+)&file:(?<fnm>.+?)\.xml(?:&options:(?<ops>.+))?/
 

--- a/rubi.sh
+++ b/rubi.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+# Helper function to detect sclibridge path
+detect_scl() {
+    if [ -f '/Users/Shared/Savant/Applications/RacePointMedia/sclibridge' ]; then
+        echo '/Users/Shared/Savant/Applications/RacePointMedia/sclibridge'
+    elif [ -f '/Users/RPM/Applications/RacePointMedia/sclibridge' ]; then
+        echo '/Users/RPM/Applications/RacePointMedia/sclibridge'
+    else
+        echo '/usr/local/bin/sclibridge'
+    fi
+}
+
 # Check for command line arguments
 if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
     echo "Usage: bash <(curl -Ls \"https://github.com/benumc/rubi/raw/main/rubi.sh\") [OPTION]"
@@ -18,13 +29,7 @@ if [ "$1" = "--removetriggers" ] || [ "$1" = "--remove" ]; then
     echo ""
     
     # Set up sclibridge path (same logic as installation)
-    if [ -f '/Users/Shared/Savant/Applications/RacePointMedia/sclibridge' ]; then
-        SCL='/Users/Shared/Savant/Applications/RacePointMedia/sclibridge'
-    elif [ -f '/Users/RPM/Applications/RacePointMedia/sclibridge' ]; then
-        SCL='/Users/RPM/Applications/RacePointMedia/sclibridge'
-    else
-        SCL='/usr/local/bin/sclibridge'
-    fi
+    SCL=$(detect_scl)
     
     echo "Using sclibridge at: $SCL"
     echo ""
@@ -54,14 +59,33 @@ if [ "$1" = "--removetriggers" ] || [ "$1" = "--remove" ]; then
     # Combine all PIDs and remove current script PID
     ALL_PIDS="$PORT_PIDS $TITLE_PIDS"
     
-    # Remove duplicates, empty entries, and current script PID
+    # Remove duplicates, empty entries, and current script PID, then verify each PID
     RUBI_PIDS=""
     for pid in $ALL_PIDS; do
         if [ -n "$pid" ] && [ "$pid" != "$$" ]; then
             # Check if this PID is already in our list
             case " $RUBI_PIDS " in
                 *" $pid "*) ;;  # Already in list
-                *) RUBI_PIDS="$RUBI_PIDS $pid" ;;  # Add to list
+                *) 
+                    # Verify this is actually a rubi-related process
+                    if command -v ps >/dev/null 2>&1; then
+                        # Use ps with different format options for better compatibility
+                        CMD=$(ps -p "$pid" -o comm= 2>/dev/null | head -n1)
+                        ARGS=$(ps -p "$pid" -o args= 2>/dev/null | head -n1)
+                        if [ -n "$CMD" ] || [ -n "$ARGS" ]; then
+                            # Check if it's a Ruby process running rubi server or has rubi title
+                            if echo "$CMD $ARGS" | grep -q "ruby.*socket.*-e" || echo "$CMD $ARGS" | grep -q "^rubi" || echo "$CMD $ARGS" | grep -q "ruby.*rubi" || [ "$CMD" = "rubi" ]; then
+                                RUBI_PIDS="$RUBI_PIDS $pid"
+                                echo "Verified rubi process (PID $pid): $CMD $ARGS"
+                            else
+                                echo "Skipping unrelated process (PID $pid): $CMD $ARGS"
+                            fi
+                        fi
+                    else
+                        # Fallback if ps is not available
+                        RUBI_PIDS="$RUBI_PIDS $pid"
+                    fi
+                    ;;
             esac
         fi
     done
@@ -69,17 +93,30 @@ if [ "$1" = "--removetriggers" ] || [ "$1" = "--remove" ]; then
     
     if [ -n "$RUBI_PIDS" ]; then
         echo "Found rubi processes: $RUBI_PIDS"
+        
+        # Pre-elevate sudo privileges to avoid multiple password prompts
+        if command -v sudo >/dev/null 2>&1; then
+            sudo -v 2>/dev/null
+        fi
+        
+        # Kill all PIDs in a single command to avoid multiple password prompts
+        VALID_PIDS=""
         for pid in $RUBI_PIDS; do
             # Double-check this isn't our own script process
             if [ "$pid" != "$$" ] && [ -n "$pid" ]; then
-                echo "Killing PID $pid..."
-                if command -v sudo >/dev/null 2>&1; then
-                    sudo kill "$pid" 2>/dev/null || echo "Could not kill PID $pid"
-                else
-                    kill "$pid" 2>/dev/null || echo "Could not kill PID $pid"
-                fi
+                VALID_PIDS="$VALID_PIDS $pid"
             fi
         done
+        VALID_PIDS=$(echo "$VALID_PIDS" | sed 's/^ *//')  # Remove leading space
+        
+        if [ -n "$VALID_PIDS" ]; then
+            echo "Killing PIDs: $VALID_PIDS"
+            if command -v sudo >/dev/null 2>&1; then
+                sudo kill $VALID_PIDS 2>/dev/null || echo "Could not kill some processes"
+            else
+                kill $VALID_PIDS 2>/dev/null || echo "Could not kill some processes"
+            fi
+        fi
         
         # Give processes time to terminate gracefully
         sleep 2
@@ -96,15 +133,11 @@ if [ "$1" = "--removetriggers" ] || [ "$1" = "--remove" ]; then
         
         if [ -n "$REMAINING" ]; then
             echo "Force killing remaining processes: $REMAINING"
-            for pid in $REMAINING; do
-                if [ "$pid" != "$$" ] && [ -n "$pid" ]; then
-                    if command -v sudo >/dev/null 2>&1; then
-                        sudo kill -9 "$pid" 2>/dev/null || echo "Could not force kill PID $pid"
-                    else
-                        kill -9 "$pid" 2>/dev/null || echo "Could not force kill PID $pid"
-                    fi
-                fi
-            done
+            if command -v sudo >/dev/null 2>&1; then
+                sudo kill -9 $REMAINING 2>/dev/null || echo "Could not force kill some processes"
+            else
+                kill -9 $REMAINING 2>/dev/null || echo "Could not force kill some processes"
+            fi
         fi
     else
         echo "No rubi processes found"
@@ -117,13 +150,7 @@ if [ "$1" = "--removetriggers" ] || [ "$1" = "--remove" ]; then
 fi
 
 # Set up sclibridge path
-if [ -f '/Users/Shared/Savant/Applications/RacePointMedia/sclibridge' ]; then
-    SCL='/Users/Shared/Savant/Applications/RacePointMedia/sclibridge'
-elif [ -f '/Users/RPM/Applications/RacePointMedia/sclibridge' ]; then
-    SCL='/Users/RPM/Applications/RacePointMedia/sclibridge'
-else
-    SCL='/usr/local/bin/sclibridge'
-fi
+SCL=$(detect_scl)
 
 echo "Using sclibridge at: $SCL"
 echo ""
@@ -144,26 +171,88 @@ sleep 2
 echo ""
 
 echo "Killing any existing rubi processes..."
-# Find rubi processes but exclude this script (bash process)
-RUBI_PIDS=$(pgrep -f "ruby.*rubi\|rubi.*ruby" 2>/dev/null | grep -v "^$$\$")
+
+# Find processes listening on port 25809 and processes with rubi title
+PORT_PIDS=""
+if command -v lsof >/dev/null 2>&1; then
+    PORT_PIDS=$(lsof -ti:25809 2>/dev/null)
+fi
+TITLE_PIDS=$(pgrep -x rubi 2>/dev/null)
+PATTERN_PIDS=$(pgrep -f "ruby.*socket.*-e\|rubi" 2>/dev/null | grep -v "^$$\$")
+
+# Combine all PIDs
+ALL_PIDS="$PORT_PIDS $TITLE_PIDS $PATTERN_PIDS"
+
+# Collect unique PIDs, prioritizing port-based detection (most reliable)
+RUBI_PIDS=""
+for pid in $ALL_PIDS; do
+    if [ -n "$pid" ] && [ "$pid" != "$$" ]; then
+        # Check if this PID is already in our list
+        case " $RUBI_PIDS " in
+            *" $pid "*) ;;  # Already in list
+            *) 
+                # If this PID was found by port detection, it's definitely a rubi process
+                case " $PORT_PIDS " in
+                    *" $pid "*)
+                        RUBI_PIDS="$RUBI_PIDS $pid"
+                        echo "Found rubi process via port 25809 (PID $pid)"
+                        ;;
+                    *)
+                        # For other PIDs, try to verify but be more lenient
+                        if command -v ps >/dev/null 2>&1; then
+                            # Use ps with different format options for better compatibility
+                            CMD=$(ps -p "$pid" -o comm= 2>/dev/null | head -n1)
+                            ARGS=$(ps -p "$pid" -o args= 2>/dev/null | head -n1)
+                            if [ -n "$CMD" ] || [ -n "$ARGS" ]; then
+                                # Check if it's a Ruby process running rubi server or has rubi title
+                                FULL_CMD="$CMD $ARGS"
+                                if echo "$FULL_CMD" | grep -q "ruby.*socket.*-e" || echo "$FULL_CMD" | grep -q "^rubi" || echo "$FULL_CMD" | grep -q "ruby.*rubi" || [ "$CMD" = "rubi" ]; then
+                                    RUBI_PIDS="$RUBI_PIDS $pid"
+                                    echo "Verified rubi process (PID $pid): $CMD $ARGS"
+                                else
+                                    # Only show skip message if we got reasonable output from ps
+                                    if echo "$FULL_CMD" | grep -qv "^%cpu %mem" && [ ${#FULL_CMD} -lt 200 ]; then
+                                        echo "Skipping unrelated process (PID $pid): $CMD $ARGS"
+                                    fi
+                                fi
+                            fi
+                        else
+                            # Fallback if ps is not available - trust title-based detection
+                            case " $TITLE_PIDS " in
+                                *" $pid "*) 
+                                    RUBI_PIDS="$RUBI_PIDS $pid"
+                                    echo "Found rubi process via title (PID $pid)"
+                                    ;;
+                            esac
+                        fi
+                        ;;
+                esac
+                ;;
+        esac
+    fi
+done
+RUBI_PIDS=$(echo "$RUBI_PIDS" | sed 's/^ *//')  # Remove leading space
+
 if [ -n "$RUBI_PIDS" ]; then
-    echo "Found rubi processes: $RUBI_PIDS"
+    echo "Found verified rubi processes: $RUBI_PIDS"
     for pid in $RUBI_PIDS; do
-        # Double-check this isn't our own script process
-        if [ "$pid" != "$$" ]; then
-            echo "Killing PID $pid..."
-            kill "$pid" 2>/dev/null || echo "Could not kill PID $pid"
-        fi
+        echo "Killing PID $pid..."
+        kill "$pid" 2>/dev/null || echo "Could not kill PID $pid"
     done
     sleep 1
+    
     # Check if any are still running and force kill
-    REMAINING=$(pgrep -f "ruby.*rubi\|rubi.*ruby" 2>/dev/null | grep -v "^$$\$")
+    REMAINING=""
+    for pid in $RUBI_PIDS; do
+        if kill -0 "$pid" 2>/dev/null; then
+            REMAINING="$REMAINING $pid"
+        fi
+    done
+    
     if [ -n "$REMAINING" ]; then
         echo "Force killing remaining processes: $REMAINING"
         for pid in $REMAINING; do
-            if [ "$pid" != "$$" ]; then
-                kill -9 "$pid" 2>/dev/null || echo "Could not force kill PID $pid"
-            fi
+            kill -9 "$pid" 2>/dev/null || echo "Could not force kill PID $pid"
         done
     fi
 else
@@ -185,6 +274,8 @@ echo ""
 
 echo "Setting up 'rubi' trigger..."
 # This trigger starts the Ruby IRB server when global.rubi changes to 1
+# Export SCL path as environment variable for Ruby to use
+export RUBI_SCL_PATH="$SCL"
 $SCL settrigger rubi 1 String global rubi "Not Equal" 1 0 "$GZN" "" "" 1 "SVC_GEN_GENERIC" "RunCLIProgram" "COMMAND_STRING" "ruby -r socket -e '
 fork do
   Process.setsid
@@ -202,20 +293,9 @@ fork do
     end
   end
 
-  SCB = if RUBY_PLATFORM.include?(\"darwin\")
-    if File.exist?(\"/Users/Shared/Savant/Applications/RacePointMedia/sclibridge\")
-      \"/Users/Shared/Savant/Applications/RacePointMedia/sclibridge\"
-    elsif File.exist?(\"/Users/RPM/Applications/RacePointMedia/sclibridge\")
-      \"/Users/RPM/Applications/RacePointMedia/sclibridge\"
-    else
-      \"/usr/local/bin/sclibridge\"
-    end
-  else
-    \"/usr/local/bin/sclibridge\"
-  end
+  SCB = ENV[\"RUBI_SCL_PATH\"]
   system(\"#{SCB} writestate global.rubi 1\")
   
-  Process.daemon
   Process.setproctitle(\"rubi\")
   
   def handle_client(client)
@@ -226,6 +306,7 @@ fork do
   
   begin
     server = TCPServer.new(\"127.0.0.1\", 25809)
+    server.setsockopt(Socket::SOL_SOCKET, Socket::SO_REUSEADDR, 1)
     loop { handle_client(server.accept) }
   rescue => e
     system(\"#{SCB} writestate global.rubierror #{e.message.gsub(\" \", \"_\")}\")

--- a/rubi.sh
+++ b/rubi.sh
@@ -1,48 +1,256 @@
-SCL='/Users/RPM/Applications/RacePointMedia/sclibridge'
-[ -d '/Users' ] || SCL='/usr/local/bin/sclibridge'
-$($SCL removetrigger rbwd)
-$($SCL removetrigger rubi)
-sleep 2
-pkill -f rubi
-GZN=$($SCL userzones | tr \\n \\0 | xargs -0 $SCL servicesforzone | grep GENERIC | head -n 1 | tr - \\n | head -n 1)
-$($SCL settrigger rbwd 1 State global CurrentMinute Equal global.CurrentMinute 0 "$GZN" "" "" 1 "SVC_GEN_GENERIC" "RunCLIProgram" "COMMAND_STRING" "lsof -i :25809 || $SCL writestate global.rubi 1 global.rubi 0")
-$($SCL settrigger rubi 1 String global rubi "Not Equal" 1 0 "$GZN" "" "" 1 "SVC_GEN_GENERIC" "RunCLIProgram" "COMMAND_STRING" "nohup ruby -r socket -e '
-  fork do
-    Process.setsid
-    exit if fork
-    STDIN.reopen(%(/dev/null))
-    STDOUT.reopen(%(/dev/null), %(a))
-    STDERR.reopen(%(/dev/null), %(a))
-    fd_max = Process.getrlimit(:NOFILE)[0]
-    3.upto(fd_max) do |i|
-      begin
-        IO.for_fd(i).close
-      rescue Errno::EBADF
-      rescue ArgumentError
-      end
-    end
+#!/bin/bash
 
-    SCB = %(#{RUBY_PLATFORM.include?(%(darwin))?%(/Users/RPM/Applications/RacePointMedia):%(/usr/local/bin)}/sclibridge)
-    %x(#{SCB} writestate global.rubi 1)
-    Process.daemon
-    Process.setproctitle(%(rubi))
-    def handle_client(c)
-        pid=fork { exec(%(irb -f --noecho --noprompt),:in=>c,:out=>c,:err=>c) }
-        c.close
-        Process.detach(pid) if pid
-    end
+# Check for command line arguments
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+    echo "Usage: bash <(curl -Ls \"https://github.com/benumc/rubi/raw/main/rubi.sh\") [OPTION]"
+    echo ""
+    echo "Options:"
+    echo "  (no args)         Install rubi IRB server triggers"
+    echo "  --removetriggers  Remove rubi triggers and processes"
+    echo "  --remove          Alias for --removetriggers"
+    echo "  --help, -h        Show this help message"
+    echo ""
+    exit 0
+fi
+
+if [ "$1" = "--removetriggers" ] || [ "$1" = "--remove" ]; then
+    echo "🗑️  REMOVING RUBI TRIGGERS"
+    echo ""
+    
+    # Set up sclibridge path (same logic as installation)
+    if [ -f '/Users/Shared/Savant/Applications/RacePointMedia/sclibridge' ]; then
+        SCL='/Users/Shared/Savant/Applications/RacePointMedia/sclibridge'
+    elif [ -f '/Users/RPM/Applications/RacePointMedia/sclibridge' ]; then
+        SCL='/Users/RPM/Applications/RacePointMedia/sclibridge'
+    else
+        SCL='/usr/local/bin/sclibridge'
+    fi
+    
+    echo "Using sclibridge at: $SCL"
+    echo ""
+    
+    # Remove triggers
+    echo "Removing 'rubi' trigger..."
+    $SCL removetrigger rubi
+    echo "✓ rubi trigger removed"
+    echo ""
+    
+    echo "Removing 'rbwd' trigger..."
+    $SCL removetrigger rbwd
+    echo "✓ rbwd trigger removed"
+    echo ""
+    
+    echo "Killing any existing rubi processes..."
+    
+    # Find processes listening on port 25809 (the IRB server port)
+    PORT_PIDS=""
+    if command -v lsof >/dev/null 2>&1; then
+        PORT_PIDS=$(lsof -ti:25809 2>/dev/null)
+    fi
+    
+    # Find processes with title "rubi" (from Process.setproctitle)
+    TITLE_PIDS=$(pgrep -x rubi 2>/dev/null)
+    
+    # Combine all PIDs and remove current script PID
+    ALL_PIDS="$PORT_PIDS $TITLE_PIDS"
+    
+    # Remove duplicates, empty entries, and current script PID
+    RUBI_PIDS=""
+    for pid in $ALL_PIDS; do
+        if [ -n "$pid" ] && [ "$pid" != "$$" ]; then
+            # Check if this PID is already in our list
+            case " $RUBI_PIDS " in
+                *" $pid "*) ;;  # Already in list
+                *) RUBI_PIDS="$RUBI_PIDS $pid" ;;  # Add to list
+            esac
+        fi
+    done
+    RUBI_PIDS=$(echo "$RUBI_PIDS" | sed 's/^ *//')  # Remove leading space
+    
+    if [ -n "$RUBI_PIDS" ]; then
+        echo "Found rubi processes: $RUBI_PIDS"
+        for pid in $RUBI_PIDS; do
+            # Double-check this isn't our own script process
+            if [ "$pid" != "$$" ] && [ -n "$pid" ]; then
+                echo "Killing PID $pid..."
+                if command -v sudo >/dev/null 2>&1; then
+                    sudo kill "$pid" 2>/dev/null || echo "Could not kill PID $pid"
+                else
+                    kill "$pid" 2>/dev/null || echo "Could not kill PID $pid"
+                fi
+            fi
+        done
+        
+        # Give processes time to terminate gracefully
+        sleep 2
+        
+        # Force kill any remaining processes
+        REMAINING=$(pgrep -f "ruby.*rubi\|rubi.*ruby\|^rubi$\|irb.*25809" 2>/dev/null | grep -v "^$$\$")
+        if command -v lsof >/dev/null 2>&1; then
+            REMAINING_PORT=$(lsof -ti:25809 2>/dev/null)
+            if [ -n "$REMAINING_PORT" ]; then
+                REMAINING="$REMAINING $REMAINING_PORT"
+            fi
+        fi
+        REMAINING=$(echo "$REMAINING" | tr ' ' '\n' | sort -u | grep -v "^$\|^$$\$" | tr '\n' ' ')
+        
+        if [ -n "$REMAINING" ]; then
+            echo "Force killing remaining processes: $REMAINING"
+            for pid in $REMAINING; do
+                if [ "$pid" != "$$" ] && [ -n "$pid" ]; then
+                    if command -v sudo >/dev/null 2>&1; then
+                        sudo kill -9 "$pid" 2>/dev/null || echo "Could not force kill PID $pid"
+                    else
+                        kill -9 "$pid" 2>/dev/null || echo "Could not force kill PID $pid"
+                    fi
+                fi
+            done
+        fi
+    else
+        echo "No rubi processes found"
+    fi
+    echo "✓ Process cleanup completed"
+    echo ""
+    
+    echo "🎉 Rubi triggers successfully removed!"
+    exit 0
+fi
+
+# Set up sclibridge path
+if [ -f '/Users/Shared/Savant/Applications/RacePointMedia/sclibridge' ]; then
+    SCL='/Users/Shared/Savant/Applications/RacePointMedia/sclibridge'
+elif [ -f '/Users/RPM/Applications/RacePointMedia/sclibridge' ]; then
+    SCL='/Users/RPM/Applications/RacePointMedia/sclibridge'
+else
+    SCL='/usr/local/bin/sclibridge'
+fi
+
+echo "Using sclibridge at: $SCL"
+echo ""
+
+# Remove existing triggers
+echo "Removing existing 'rbwd' trigger..."
+$SCL removetrigger rbwd
+echo "✓ rbwd trigger removal completed"
+echo ""
+
+echo "Removing existing 'rubi' trigger..."
+$SCL removetrigger rubi
+echo "✓ rubi trigger removal completed"
+echo ""
+
+echo "Waiting 2 seconds for cleanup..."
+sleep 2
+echo ""
+
+echo "Killing any existing rubi processes..."
+# Find rubi processes but exclude this script (bash process)
+RUBI_PIDS=$(pgrep -f "ruby.*rubi\|rubi.*ruby" 2>/dev/null | grep -v "^$$\$")
+if [ -n "$RUBI_PIDS" ]; then
+    echo "Found rubi processes: $RUBI_PIDS"
+    for pid in $RUBI_PIDS; do
+        # Double-check this isn't our own script process
+        if [ "$pid" != "$$" ]; then
+            echo "Killing PID $pid..."
+            kill "$pid" 2>/dev/null || echo "Could not kill PID $pid"
+        fi
+    done
+    sleep 1
+    # Check if any are still running and force kill
+    REMAINING=$(pgrep -f "ruby.*rubi\|rubi.*ruby" 2>/dev/null | grep -v "^$$\$")
+    if [ -n "$REMAINING" ]; then
+        echo "Force killing remaining processes: $REMAINING"
+        for pid in $REMAINING; do
+            if [ "$pid" != "$$" ]; then
+                kill -9 "$pid" 2>/dev/null || echo "Could not force kill PID $pid"
+            fi
+        done
+    fi
+else
+    echo "No rubi processes found"
+fi
+echo "✓ Process cleanup completed"
+echo ""
+
+echo "Getting generic zone name..."
+GZN=$($SCL userzones | tr \\n \\0 | xargs -0 $SCL servicesforzone | grep GENERIC | head -n 1 | tr - \\n | head -n 1)
+echo "✓ Found generic zone: $GZN"
+echo ""
+
+echo "Setting up 'rbwd' (Ruby Watchdog) trigger..."
+# This trigger checks if the rubi server is running and starts it if needed
+$SCL settrigger rbwd 1 State global CurrentMinute Equal global.CurrentMinute 0 "$GZN" "" "" 1 "SVC_GEN_GENERIC" "RunCLIProgram" "COMMAND_STRING" "lsof -i :25809 || $SCL writestate global.rubi 1 global.rubi 0"
+echo "✓ rbwd trigger setup completed"
+echo ""
+
+echo "Setting up 'rubi' trigger..."
+# This trigger starts the Ruby IRB server when global.rubi changes to 1
+$SCL settrigger rubi 1 String global rubi "Not Equal" 1 0 "$GZN" "" "" 1 "SVC_GEN_GENERIC" "RunCLIProgram" "COMMAND_STRING" "ruby -r socket -e '
+fork do
+  Process.setsid
+  exit if fork
+  STDIN.reopen(\"/dev/null\")
+  STDOUT.reopen(\"/dev/null\", \"a\")
+  STDERR.reopen(\"/dev/null\", \"a\")
+  
+  # Close all file descriptors except standard ones
+  fd_max = Process.getrlimit(:NOFILE)[0]
+  3.upto(fd_max) do |i|
     begin
-        server=TCPServer.new(%(127.0.0.1),25809)
-        loop {handle_client(server.accept)}
-    rescue=>e
-        %x(#{SCB} writestate global.rubierror #{e.message.gsub(%( ), %(_))})
-    ensure
-        if server
-        server.close
-        %x(#{SCB} writestate global.rubi 0)
-        end
+      IO.for_fd(i).close
+    rescue Errno::EBADF, ArgumentError
     end
   end
-  ' &")
-$($SCL writestate global.rubi 2)
-echo "Start-up Triggers installed. Can be uninstalled with command 'sclibridge removetrigger rubi && sclibridge removetrigger rbwd && sleep 5 && pkill -f rubi'"
+
+  SCB = if RUBY_PLATFORM.include?(\"darwin\")
+    if File.exist?(\"/Users/Shared/Savant/Applications/RacePointMedia/sclibridge\")
+      \"/Users/Shared/Savant/Applications/RacePointMedia/sclibridge\"
+    elsif File.exist?(\"/Users/RPM/Applications/RacePointMedia/sclibridge\")
+      \"/Users/RPM/Applications/RacePointMedia/sclibridge\"
+    else
+      \"/usr/local/bin/sclibridge\"
+    end
+  else
+    \"/usr/local/bin/sclibridge\"
+  end
+  system(\"#{SCB} writestate global.rubi 1\")
+  
+  Process.daemon
+  Process.setproctitle(\"rubi\")
+  
+  def handle_client(client)
+    pid = fork { exec(\"irb -f --noecho --noprompt\", :in=>client, :out=>client, :err=>client) }
+    client.close
+    Process.detach(pid) if pid
+  end
+  
+  begin
+    server = TCPServer.new(\"127.0.0.1\", 25809)
+    loop { handle_client(server.accept) }
+  rescue => e
+    system(\"#{SCB} writestate global.rubierror #{e.message.gsub(\" \", \"_\")}\")
+  ensure
+    if server
+      server.close
+      system(\"#{SCB} writestate global.rubi 0\")
+    end
+  end
+end
+' &"
+echo "✓ rubi trigger setup completed"
+echo ""
+
+echo "Initializing rubi state..."
+$SCL writestate global.rubi 2
+echo "✓ rubi state initialized to 2"
+echo ""
+
+echo "🎉 Rubi IRB Server triggers installed successfully!"
+echo ""
+echo "📋 NEXT STEPS:"
+echo "1. Install the M2 or Benumc Script Bridge v2 Profile in your Savant configuration"
+echo "2. Install any other profiles (like Ezlo Hub) that contain scripts after the 'splitScript' marker"
+echo "3. The M2 or Benumc Script Bridge will listen on port 25768 and execute profile scripts"
+echo "4. The Rubi IRB server will run on port 25809 for interactive Ruby sessions"
+echo ""
+echo "📝 To uninstall: bash <(curl -Ls \"https://github.com/benumc/rubi/raw/main/rubi.sh\") --removetriggers"

--- a/script_bridge.rb
+++ b/script_bridge.rb
@@ -43,7 +43,7 @@ rescue Errno::EADDRINUSE
     end
   end
   
-  # Method 2: Try netstat on macOS
+  # Method 2: Try netstat (works on both macOS and Linux)
   if !killed
     netstat_output = `netstat -an 2>/dev/null | grep ':25768 '`.strip
     if !netstat_output.empty?

--- a/script_bridge.rb
+++ b/script_bridge.rb
@@ -1,48 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<component xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:noNamespaceSchemaLocation="racepoint_component_profile.xsd" manufacturer="Benumc"
-  model="script-bridge-rubi" device_class="Remote_control" minimum_component_engine_version="0"
-  rpm_xml_version="2.12">
-
-  <notes>
-    Drop in replacement for existing srcipt-bridge to work with rubi co-processor.
-
-    New profiles should be built to work directly with rubi but this profile can work as an in-between until they are complete
-
-    Address on wire should be set to 127.0.0.1
-
-    <![CDATA[ 
-    Rubi can be installed on the host by connecting via terminal and running:
-
-    bash <(curl -Ls "https://github.com/benumc/rubi/raw/main/rubi.sh")
-
-    ]]>
-  </notes>
-  <control_interfaces preferred="ip">
-    <ip port="25809" response_time_length_ms="1000" protocol="tcp">
-      <send_postfix type="hex">0D0A</send_postfix>
-      <receive_end_condition test_condition="data" type="hex">0A</receive_end_condition>
-    </ip>
-  </control_interfaces>
-  <media_interfaces>
-    <data name_on_component="Ethernet">
-      <combined_media>
-        <data_media type="ethernet"/>
-        <control port="25809"/>
-      </combined_media>
-    </data>
-  </media_interfaces>
-  <state_variable_list>
-  </state_variable_list>
-  <logical_component logical_component_name="Component">
-    <implementation/>
-    <custom_component_actions>
-      <action name="CONNECT">
-        <command_interface interface="ip">
-          <command response_required="no">
-            <command_string type="character"/>
-            <parameter_list>
-              <parameter parameter_data_type="character"><![CDATA[
 require 'socket'
 include Socket::Constants
 
@@ -168,15 +123,3 @@ else
   puts "Failed to start server - exiting"
   exit 1
 end
-
-#]]>
-
-              </parameter>
-            </parameter_list>
-          </command>
-        </command_interface>
-        <execute_on_schedule period_ms="0"/>
-      </action>
-    </custom_component_actions>
-  </logical_component>
-</component>


### PR DESCRIPTION
…ackwards compatibility

Fixes #1

- Add backwards compatible sclibridge path detection
  * Checks for new path: /Users/Shared/Savant/Applications/RacePointMedia/sclibridge
  * Falls back to old path: /Users/RPM/Applications/RacePointMedia/sclibridge
  * Uses fallback path: /usr/local/bin/sclibridge for Linux/other systems
  * Applied to both bash SCL variable and Ruby SCB variable

- Add command line argument support
  * --removetriggers / --remove: Remove rubi triggers and processes
  * --help / -h: Show usage information
  * Default behavior (no args): Install triggers as before

- Improve removal process for macOS 15.5+ compatibility
  * Handle "Operation not permitted" errors gracefully
  * Enhanced process detection using port 25809 and process title "rubi"
  * Use same conditional sclibridge path logic for removal
  * Fix script hanging issues by excluding self from process searches

- Fix process cleanup reliability
  * Prevent script from killing itself during process cleanup
  * Add proper error handling for pkill operations
  * Use individual PID targeting instead of pattern matching

- Update installation/removal instructions
  * Reflect actual usage pattern: bash <(curl -Ls "URL")
  * Show correct uninstall command using curl method
  * Update help text with proper usage examples

- Update branding references
  * Change "M2 Script Bridge" to "M2 or Benumc Script Bridge"

This ensures the script works across old macOS, new macOS 15.5+ with SavantOS 11.0.5+, and Linux systems while providing a user-friendly removal mechanism.